### PR TITLE
'Stop' function, to immediately call callback w/o error

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -236,7 +236,7 @@
             return callback(null);
         }
         _each(object, function (value, key) {
-            iterator(object[key], key, only_once(done));
+            iterator(object[key], key, only_once(done), only_once(skip));
         });
         function done(err) {
             if (err) {
@@ -248,6 +248,9 @@
                     callback(null);
                 }
             }
+        }
+        function skip() {
+            callback(null);
         }
     };
 
@@ -278,8 +281,11 @@
                         }
                     }
                 }
-            }));
+            }), only_once(skip));
             sync = false;
+        }
+        function skip() {
+            callback(null);
         }
         iterate();
     };
@@ -328,9 +334,13 @@
                         else {
                             replenish();
                         }
-                    }));
+                    }), only_once(skip));
                 }
             })();
+
+            function skip() {
+                callback(null);
+            }
         };
     }
 
@@ -673,15 +683,19 @@
                     else {
                         args.push(callback);
                     }
+                    args.push(skip);
                     ensureAsync(iterator).apply(null, args);
                 }
             });
+        }
+        function skip() {
+            callback(null);
         }
         wrapIterator(async.iterator(tasks))();
     };
 
     function _parallel(eachfn, tasks, callback) {
-        callback = callback || noop;
+        callback = _once(callback || noop);
         var results = _isArrayLike(tasks) ? [] : {};
 
         eachfn(tasks, function (task, key, callback) {
@@ -691,10 +705,13 @@
                 }
                 results[key] = args;
                 callback(err);
-            }));
+            }, skip));
         }, function (err) {
             callback(err, results);
         });
+        function skip() {
+            return callback(null);
+        }
     }
 
     async.parallel = function (tasks, callback) {

--- a/lib/async.js
+++ b/lib/async.js
@@ -236,7 +236,7 @@
             return callback(null);
         }
         _each(object, function (value, key) {
-            iterator(object[key], key, only_once(done), only_once(skip));
+            iterator(object[key], key, only_once(done), only_once(stop));
         });
         function done(err) {
             if (err) {
@@ -249,7 +249,7 @@
                 }
             }
         }
-        function skip() {
+        function stop() {
             callback(null);
         }
     };
@@ -281,10 +281,10 @@
                         }
                     }
                 }
-            }), only_once(skip));
+            }), only_once(stop));
             sync = false;
         }
-        function skip() {
+        function stop() {
             callback(null);
         }
         iterate();
@@ -334,11 +334,10 @@
                         else {
                             replenish();
                         }
-                    }), only_once(skip));
+                    }), only_once(stop));
                 }
             })();
-
-            function skip() {
+            function stop() {
                 callback(null);
             }
         };
@@ -683,12 +682,12 @@
                     else {
                         args.push(callback);
                     }
-                    args.push(skip);
+                    args.push(stop);
                     ensureAsync(iterator, true).apply(null, args);
                 }
             });
         }
-        function skip() {
+        function stop() {
             return callback(null);
         }
         wrapIterator(async.iterator(tasks))();
@@ -1168,7 +1167,7 @@
 
     function ensureAsync(fn, pop) {
         return _restParam(function (args) {
-            // may have to pop skip
+            // may have to pop stop function
             if (pop) {
                 args.pop();
             }

--- a/lib/async.js
+++ b/lib/async.js
@@ -684,18 +684,18 @@
                         args.push(callback);
                     }
                     args.push(skip);
-                    ensureAsync(iterator).apply(null, args);
+                    ensureAsync(iterator, true).apply(null, args);
                 }
             });
         }
         function skip() {
-            callback(null);
+            return callback(null);
         }
         wrapIterator(async.iterator(tasks))();
     };
 
     function _parallel(eachfn, tasks, callback) {
-        callback = _once(callback || noop);
+        callback = callback || noop;
         var results = _isArrayLike(tasks) ? [] : {};
 
         eachfn(tasks, function (task, key, callback) {
@@ -705,13 +705,10 @@
                 }
                 results[key] = args;
                 callback(err);
-            }, skip));
+            }));
         }, function (err) {
             callback(err, results);
         });
-        function skip() {
-            return callback(null);
-        }
     }
 
     async.parallel = function (tasks, callback) {
@@ -1169,8 +1166,12 @@
         next();
     };
 
-    function ensureAsync(fn) {
+    function ensureAsync(fn, pop) {
         return _restParam(function (args) {
+            // may have to pop skip
+            if (pop) {
+                args.pop();
+            }
             var callback = args.pop();
             args.push(function () {
                 var innerArgs = arguments;

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -680,148 +680,148 @@ exports['retry as an embedded task with interval'] = function(test) {
 exports['waterfall'] = {
 
     'basic': function(test){
-    test.expect(7);
-    var call_order = [];
-    async.waterfall([
-        function(callback){
-            call_order.push('fn1');
-            setTimeout(function(){callback(null, 'one', 'two');}, 0);
-        },
-        function(arg1, arg2, callback){
-            call_order.push('fn2');
-            test.equals(arg1, 'one');
-            test.equals(arg2, 'two');
-            setTimeout(function(){callback(null, arg1, arg2, 'three');}, 25);
-        },
-        function(arg1, arg2, arg3, callback){
-            call_order.push('fn3');
-            test.equals(arg1, 'one');
-            test.equals(arg2, 'two');
-            test.equals(arg3, 'three');
-            callback(null, 'four');
-        },
-        function(arg4, callback){
-            call_order.push('fn4');
-            test.same(call_order, ['fn1','fn2','fn3','fn4']);
-            callback(null, 'test');
-        }
-    ], function(err){
-        test.ok(err === null, err + " passed instead of 'null'");
-        test.done();
-    });
-},
-
-    'empty array': function(test){
-    async.waterfall([], function(err){
-        if (err) throw err;
-        test.done();
-    });
-},
-
-    'non-array': function(test){
-    async.waterfall({}, function(err){
-        test.equals(err.message, 'First argument to waterfall must be an array of functions');
-        test.done();
-    });
-},
-
-    'no callback': function(test){
-    async.waterfall([
-        function(callback){callback();},
-        function(callback){callback(); test.done();}
-    ]);
-},
-
-    'async': function(test){
-    var call_order = [];
-    async.waterfall([
-        function(callback){
-            call_order.push(1);
-            callback();
-            call_order.push(2);
-        },
-        function(callback){
-            call_order.push(3);
-            callback();
-        },
-        function(){
-            test.same(call_order, [1,2,3]);
-            test.done();
-        }
-    ]);
-},
-
-    'error': function(test){
-    test.expect(1);
-    async.waterfall([
-        function(callback){
-            callback('error');
-        },
-        function(callback){
-            test.ok(false, 'next function should not be called');
-            callback();
-        }
-    ], function(err){
-        test.equals(err, 'error');
-    });
-    setTimeout(test.done, 50);
-},
-
-    'multiple callback calls': function(test){
-    var call_order = [];
-    var arr = [
-        function(callback){
-            call_order.push(1);
-            // call the callback twice. this should call function 2 twice
-            callback(null, 'one', 'two');
-            callback(null, 'one', 'two');
-        },
-        function(arg1, arg2, callback){
-            call_order.push(2);
-            callback(null, arg1, arg2, 'three');
-        },
-        function(arg1, arg2, arg3, callback){
-            call_order.push(3);
-            callback(null, 'four');
-        },
-        function(/*arg4*/){
-            call_order.push(4);
-            arr[3] = function(){
-                call_order.push(4);
-                test.same(call_order, [1,2,2,3,3,4,4]);
-                test.done();
-            };
-        }
-    ];
-    async.waterfall(arr);
-},
-
-    'call in another context': function(test) {
-    if (isBrowser()) {
-        // node only test
-        test.done();
-        return;
-    }
-
-    var vm = require('vm');
-    var sandbox = {
-        async: async,
-        test: test
-    };
-
-    var fn = "(" + (function () {
-        async.waterfall([function (callback) {
-            callback();
-        }], function (err) {
-            if (err) {
-                return test.done(err);
+        test.expect(7);
+        var call_order = [];
+        async.waterfall([
+            function(callback){
+                call_order.push('fn1');
+                setTimeout(function(){callback(null, 'one', 'two');}, 0);
+            },
+            function(arg1, arg2, callback){
+                call_order.push('fn2');
+                test.equals(arg1, 'one');
+                test.equals(arg2, 'two');
+                setTimeout(function(){callback(null, arg1, arg2, 'three');}, 25);
+            },
+            function(arg1, arg2, arg3, callback){
+                call_order.push('fn3');
+                test.equals(arg1, 'one');
+                test.equals(arg2, 'two');
+                test.equals(arg3, 'three');
+                callback(null, 'four');
+            },
+            function(arg4, callback){
+                call_order.push('fn4');
+                test.same(call_order, ['fn1','fn2','fn3','fn4']);
+                callback(null, 'test');
             }
+        ], function(err){
+            test.ok(err === null, err + " passed instead of 'null'");
             test.done();
         });
-    }).toString() + "())";
+    },
 
-    vm.runInNewContext(fn, sandbox);
-}
+    'empty array': function(test){
+        async.waterfall([], function(err){
+            if (err) throw err;
+            test.done();
+        });
+    },
+
+    'non-array': function(test){
+        async.waterfall({}, function(err){
+            test.equals(err.message, 'First argument to waterfall must be an array of functions');
+            test.done();
+        });
+    },
+
+    'no callback': function(test){
+        async.waterfall([
+            function(callback){callback();},
+            function(callback){callback(); test.done();}
+        ]);
+    },
+
+    'async': function(test){
+        var call_order = [];
+        async.waterfall([
+            function(callback){
+                call_order.push(1);
+                callback();
+                call_order.push(2);
+            },
+            function(callback){
+                call_order.push(3);
+                callback();
+            },
+            function(){
+                test.same(call_order, [1,2,3]);
+                test.done();
+            }
+        ]);
+    },
+
+    'error': function(test){
+        test.expect(1);
+        async.waterfall([
+            function(callback){
+                callback('error');
+            },
+            function(callback){
+                test.ok(false, 'next function should not be called');
+                callback();
+            }
+        ], function(err){
+            test.equals(err, 'error');
+        });
+        setTimeout(test.done, 50);
+    },
+
+    'multiple callback calls': function(test){
+        var call_order = [];
+        var arr = [
+            function(callback){
+                call_order.push(1);
+                // call the callback twice. this should call function 2 twice
+                callback(null, 'one', 'two');
+                callback(null, 'one', 'two');
+            },
+            function(arg1, arg2, callback){
+                call_order.push(2);
+                callback(null, arg1, arg2, 'three');
+            },
+            function(arg1, arg2, arg3, callback){
+                call_order.push(3);
+                callback(null, 'four');
+            },
+            function(/*arg4*/){
+                call_order.push(4);
+                arr[3] = function(){
+                    call_order.push(4);
+                    test.same(call_order, [1,2,2,3,3,4,4]);
+                    test.done();
+                };
+            }
+        ];
+        async.waterfall(arr);
+    },
+
+    'call in another context': function(test) {
+        if (isBrowser()) {
+            // node only test
+            test.done();
+            return;
+        }
+
+        var vm = require('vm');
+        var sandbox = {
+            async: async,
+            test: test
+        };
+
+        var fn = "(" + (function () {
+            async.waterfall([function (callback) {
+                callback();
+            }], function (err) {
+                if (err) {
+                    return test.done(err);
+                }
+                test.done();
+            });
+        }).toString() + "())";
+
+        vm.runInNewContext(fn, sandbox);
+    }
 
 };
 


### PR DESCRIPTION
Async is a great library to avoid callback hell. But, sometimes in the middle of deep series/waterfall logic I  want to break out, and jump immediately to the callback w/o error. There are a couple of ways I do this now:
#### Example 1

``` js
var series = [];
var someBool = false;

series.push(function(callback) {
  /**
    some logic, may set someBool to true, may not
  */
  callback();
});

series.push(function(callback) {
  if (someBool) {
    return callback();
  }

  /**
    additional logic
  */
  callback();
});

async.series(series, function(err) { });
```
#### Example 2

``` js
var series = [];

series.push(function(callback) {
  var someBool = false;

  /**
    some logic, may set someBool to true, may not
  */

  if (someBool) {
    var passiveError = new Error('ignored');
    passiveError.ignore = true;
    return callback(passiveError);
  }

  callback();
});

series.push(function(callback) {
  /**
    additional logic
  */
  callback();
});

async.series(series, function(err) {
  if (err && !err.ignore) {
    // deal with error
    return;
  }
});
```
### Better solution

As you can imagine, those solutions can be a pain. Especially considering much longer series, waterfalls (where `someBool` may be passed down the chain), etc.

Instead, it'd be nice to be able to do this:

``` js
var series = [];

series.push(function(callback, stop) {
  var someBool = false;

  /**
    some logic, may set someBool to true, may not
  */

  if (someBool) {
    return stop();
  }

  callback();
});

series.push(function(callback) {
  /**
    additional logic
  */
  callback();
});

async.series(series, function(err) { });
```
